### PR TITLE
Add prefetch option to Astro configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -36,4 +36,7 @@ export default defineConfig({
     gfm: true,
     smartypants: true,
   },
+  prefetch: {
+    prefetchAll: true
+  }
 });


### PR DESCRIPTION
This pull request makes a small configuration change to the `astro.config.mjs` file. The change enables prefetching for all links in the application by adding a `prefetch` option with `prefetchAll: true`.

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR39-R41): Added the `prefetch` option with `prefetchAll: true` to enable prefetching for all links.