### PR TITLE
Add view transitions

### DIFF
--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from "astro:transitions";
 import { ThemeScript } from "astro-theme-toggle";
 import NavBar from "../components/NavBar.astro";
 import "../styles/global.css";
@@ -13,6 +14,7 @@ const { title } = Astro.props;
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<ThemeScript />
+		<ClientRouter />
 		<title>{title}</title>
 	</head>
 	<body class="max-w-screen-md mx-auto">


### PR DESCRIPTION
This pull request introduces a small enhancement to the `HomeLayout.astro` file by incorporating the `ClientRouter` component for enabling page transitions.

* [`src/layouts/HomeLayout.astro`](diffhunk://#diff-39c5d7b12c3525fb3097716b67a61f490a2aafb95d959ca0898e46d9cbbfc761R2): Added the `ClientRouter` import and included it in the layout to enable client-side transitions. [[1]](diffhunk://#diff-39c5d7b12c3525fb3097716b67a61f490a2aafb95d959ca0898e46d9cbbfc761R2) [[2]](diffhunk://#diff-39c5d7b12c3525fb3097716b67a61f490a2aafb95d959ca0898e46d9cbbfc761R17)