### PR TITLE
Reorganize blog-content css styles

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -41,9 +41,6 @@
   @apply text-3xl font-medium my-4;
 }
 
-.blog-content a[href^="#"] {
-  @apply hover:underline;
-}
 
 /* Lists */
 .blog-content ul {
@@ -89,10 +86,16 @@
 }
 
 /* Links */
-.blog-content a[href^="http"],
+.blog-content a[href^="#"] {
+  @apply hover:underline;
+}
+
+.blog-content a[href^="http"] {
+  @apply underline;
+}
+
 .blog-content a[href^="http"]::after {
   content: " ↗";
-  @apply underline;
 }
 
 .blog-content a[href^="/"] {


### PR DESCRIPTION
This pull request refactors the `src/styles/global.css` file to streamline and reorganize styling rules for blog content elements. The changes primarily focus on improving consistency and readability of the CSS by consolidating selectors and adjusting link styles.

### Consolidation of Heading Styles:
* Combined selectors for `h3` and `h4` under a shared rule, and similarly for `h5` and `h6`, to reduce redundancy in styling definitions. (`[src/styles/global.cssL34-L52](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL34-L52)`)

### Link Styling Adjustments:
* Moved the `hover:underline` rule for anchor links starting with `#` to a new section and reintroduced it for better organization. (`[src/styles/global.cssL98-L101](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL98-L101)`)
* Updated the styling for external links (`a[href^="http"]`) by separating the `underline` rule from the `::after` pseudo-element, ensuring clearer and more maintainable code. (`[src/styles/global.cssL98-L101](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL98-L101)`)