### PR TITLE
Remove about page

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -3,7 +3,6 @@ import { Toggle } from "astro-theme-toggle";
 
 const links = [
   { href: "/blog", label: "Blog" },
-  { href: "/about", label: "About" },
 ];
 ---
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,9 +1,0 @@
----
-import HomeLayout from "../layouts/HomeLayout.astro";
----
-
-<HomeLayout title="About">
-	<main class="max-w-screen-md mx-auto px-4 py-12 my-8">
-		<h1 class="text-6xl font-bold mb-8">WIP</h1>
-	</main>
-</HomeLayout>


### PR DESCRIPTION
This pull request removes the "About" page and the corresponding navigation link from the codebase. The changes clean up the code by eliminating unused components and references.

### Removal of the "About" page:

* [`src/pages/about.astro`](diffhunk://#diff-cb33463363c150558e340277672bb5c583640ddb38012f53a33ed69125d92038L1-L9): Deleted the entire file, which included the `HomeLayout` component and placeholder content for the "About" page.

### Update to navigation links:

* [`src/components/NavBar.astro`](diffhunk://#diff-c2fa723e39cc162a71e7efe3c4d4264643f48e67c55683d89aa0ca3ff2bfbc81L6): Removed the "About" link from the navigation menu.