### PR TITLE
Add published date and reading time to blog entries

### DIFF
--- a/src/data/blog/hello-world.md
+++ b/src/data/blog/hello-world.md
@@ -3,9 +3,8 @@ title: "Hello World"
 description: "A brief entry on the motivation and tech-stack behind this website."
 author: "Luis Fonseca"
 published_date: "07-30-2025"
+reading_time: 2
 ---
-
-# Hello world
 
 Hello world, this is my first ever blog post! I hope there are many more to come with more interesting topics, but for now I would like to talk about why I decided to make this website and how I did it.
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -15,8 +15,32 @@ const { Content } = await render(post);
 
 <HomeLayout title={`${post.data.title}`}>
   <main class="px-4 py-12 my-8">
-    <article class="blog-content">
-      <Content />
+    <article>
+      <section>
+        <h1 class="text-3xl font-bold mb-0">{post.data.title}</h1>
+        <div class="flex align-text-top gap-3 dark:text-white/60 text-black/60 text-base">
+          <span>
+            {
+              post.data.published_date.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })
+            }</span
+          >
+          <span class="font-bold">▪</span>
+          <span>
+            {
+              post.data.reading_time
+                ? `${post.data.reading_time} min read`
+                : "-"
+            }</span
+          >
+        </div>
+      </section>
+      <section class="blog-content">
+        <Content />
+      </section>
     </article>
   </main>
 </HomeLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -19,7 +19,7 @@ const { Content } = await render(post);
       <section>
         <h1 class="text-3xl font-bold mb-0">{post.data.title}</h1>
         <div
-          class="flex align-text-top gap-3 dark:text-white/60 text-black/60 text-base"
+          class="flex gap-3 dark:text-white/60 text-black/60 text-base"
         >
           <span>
             {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -18,7 +18,9 @@ const { Content } = await render(post);
     <article>
       <section>
         <h1 class="text-3xl font-bold mb-0">{post.data.title}</h1>
-        <div class="flex align-text-top gap-3 dark:text-white/60 text-black/60 text-base">
+        <div
+          class="flex align-text-top gap-3 dark:text-white/60 text-black/60 text-base"
+        >
           <span>
             {
               post.data.published_date.toLocaleDateString("en-US", {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ import HomeLayout from "../layouts/HomeLayout.astro";
 			>
 		</p>
 	</main>
-	<footer class="text-center">
+	<footer>
 		<nav class="flex justify-center gap-4">
 			<a
 				href="mailto:luis.fonsecachinchilla@ucr.ac.cr"


### PR DESCRIPTION
This pull request introduces improvements to the blog post structure and layout, including enhanced metadata handling and formatting for better readability. The most significant changes are the addition of a `reading_time` property to blog posts and updates to the blog post rendering logic to display this metadata.

### Blog Post Metadata Enhancements:
* [`src/data/blog/hello-world.md`](diffhunk://#diff-695672c4894f584e02f6699bc2b5c17479d076f6698eefcdf53b53dc133700a5R6-L9): Added a `reading_time` property to the blog post metadata to indicate estimated reading time.

### Blog Post Layout Updates:
* `src/pages/blog/[...slug].astro`: Updated the blog post layout to include a new section displaying the title, published date, and reading time in a formatted manner. This improves the visual presentation of blog metadata. ([src/pages/blog/[...slug].astroL18-R45](diffhunk://#diff-58f768268bbbc17f4c98b8e28c3750d290d43220e52698462b5243f6ebdb3b91L18-R45))

### Footer Simplification:
* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L19-R19): Simplified the footer structure by removing the `text-center` class from the `<footer>` element.