### PR TITLE
Change max-w-screen to sm, add <p> text colors

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -32,7 +32,7 @@ export default defineConfig({
         light: 'catppuccin-latte',
         dark: 'catppuccin-mocha',
       },
-      wrap: true,
+      wrap: false,
     },
     syntaxHighlight: 'shiki',
     gfm: true,

--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -11,7 +11,7 @@ const { title, description, published_date, id } = Astro.props as Props;
 <a href={`/blog/${id}`} class="pb-2 group">
   <div class="flex items-baseline gap-1">
     <h2 class="text-lg font-bold group-hover:underline">{title}</h2>
-    <p class="text-black/60 dark:text-white/60">{published_date}</p>
+    <span class="text-black/60 dark:text-white/60">{published_date}</span>
   </div>
   <p class="text-lg">{description}</p>
 </a>

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -17,7 +17,7 @@ const { title } = Astro.props;
 		<ClientRouter />
 		<title>{title}</title>
 	</head>
-	<body class="max-w-screen-md mx-auto">
+	<body class="max-w-screen-sm mx-auto">
 		<header>
 			<NavBar />
 		</header>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,10 @@ h6 {
   font-family: 'Roboto Slab', serif;
 }
 
+p {
+  @apply text-black/90 dark:text-white/90;
+}
+
 .dark {
   background-color: #0f1115;
 }
@@ -231,7 +235,7 @@ h6 {
 /* Code */
 /* The code block styles are applied by shiki */
 .blog-content pre {
-  @apply p-4 my-4 rounded-lg;
+  @apply p-3 my-4 rounded-lg;
 }
 
 .blog-content code {


### PR DESCRIPTION
This pull request focuses on improving the visual consistency and layout of the blog and home page, as well as refining code block styling and text color. The main changes involve adjusting layout widths, updating text color application, and making minor tweaks to code block appearance.

**Layout and Styling Adjustments:**

* Changed the maximum width of the home page body container from `max-w-screen-md` to `max-w-screen-sm` in `HomeLayout.astro` to create a narrower, more focused layout.
* Applied consistent text color to all `<p>` elements for better readability in both light and dark modes by adding a new CSS rule in `global.css`.

**Component Structure and Semantics:**

* Replaced the `<p>` tag with a `<span>` for the `published_date` in `BlogCard.astro` to improve semantic structure within the heading group.

**Code Block and Markdown Presentation:**

* Reduced padding on code blocks in blog content from `p-4` to `p-3` for a more compact appearance in `global.css`.
* Disabled line wrapping in the Markdown configuration by setting `wrap: false` in `astro.config.mjs`, ensuring code blocks maintain horizontal scroll and do not wrap lines.