### PR TITLE
Show the 3 most recent blog posts, add all blog posts page

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -4,19 +4,22 @@ import HomeLayout from "../layouts/HomeLayout.astro";
 import BlogCard from "../components/BlogCard.astro";
 
 const posts = await getCollection("blog");
+const recentPostsCount = 3;
+
 const sortedPosts = posts.sort(
   (a, b) =>
     new Date(b.data.published_date).getTime() -
     new Date(a.data.published_date).getTime(),
 );
+const recentPosts = sortedPosts.slice(0, recentPostsCount);
 ---
 
 <HomeLayout title="Blog">
   <main class="px-4 py-12 my-8">
-    <h1 class="text-3xl font-bold mb-8">Blog</h1>
+    <h1 class="text-3xl font-bold mb-8">Recent blog posts</h1>
     <div class="grid gap-2">
       {
-        sortedPosts.map((post) => (
+        recentPosts.map((post) => (
           <BlogCard
             title={post.data.title}
             description={post.data.description}
@@ -33,5 +36,12 @@ const sortedPosts = posts.sort(
         ))
       }
     </div>
+    {
+      sortedPosts.length > recentPostsCount ? (
+        <span class="my-2 flex justify-end text-sm font-bold underline">
+          <a href="/blog/all">See all blog posts</a>
+        </span>
+      ) : null
+    }
   </main>
 </HomeLayout>

--- a/src/pages/blog/all.astro
+++ b/src/pages/blog/all.astro
@@ -1,0 +1,37 @@
+---
+import { getCollection } from "astro:content";
+import HomeLayout from "../../layouts/HomeLayout.astro";
+import BlogCard from "../../components/BlogCard.astro";
+
+const posts = await getCollection("blog");
+const sortedPosts = posts.sort(
+  (a, b) =>
+    new Date(b.data.published_date).getTime() -
+    new Date(a.data.published_date).getTime(),
+);
+---
+
+<HomeLayout title="All blog posts">
+  <main class="px-4 py-12 my-8">
+    <h1 class="text-3xl font-bold mb-8">All blog posts</h1>
+    <div class="grid gap-2">
+      {
+        sortedPosts.map((post) => (
+          <BlogCard
+            title={post.data.title}
+            description={post.data.description}
+            published_date={post.data.published_date.toLocaleDateString(
+              "en-US",
+              {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              },
+            )}
+            id={post.id}
+          />
+        ))
+      }
+    </div>
+  </main>
+</HomeLayout>


### PR DESCRIPTION
This pull request updates the blog listing experience by showing only the most recent blog posts on the main blog page and adding a new page to display all blog posts. The main blog page now highlights the latest posts and provides a link to view the complete archive.

**Blog listing improvements:**

* The main blog page (`src/pages/blog.astro`) now displays only the three most recent blog posts, instead of the full list. The section title was updated to "Recent blog posts".
* A conditional "See all blog posts" link has been added to the main blog page, which appears only if there are more posts than the recent posts count. This link directs users to the new all-posts page.

**New all-posts page:**

* Introduced a new page at `/blog/all` (`src/pages/blog/all.astro`) that lists all blog posts in reverse chronological order, allowing users to browse the complete blog archive.