### PR TITLE
Remove dark theme toggle

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,7 +30,6 @@ export default defineConfig({
     shikiConfig: {
       themes: {
         light: 'catppuccin-latte',
-        dark: 'catppuccin-mocha',
       },
       wrap: false,
     },

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@lucide/astro": "^0.525.0",
         "@tailwindcss/vite": "^4.1.11",
         "astro": "5.13.8",
-        "astro-theme-toggle": "^0.6.1",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-external-links": "^3.0.0",
         "tailwindcss": "^4.1.11",
@@ -292,8 +291,6 @@
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
     "astro": ["astro@5.13.8", "", { "dependencies": { "@astrojs/compiler": "^2.12.2", "@astrojs/internal-helpers": "0.7.2", "@astrojs/markdown-remark": "6.3.6", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^2.4.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.2.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.0", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.0.2", "cssesc": "^3.0.0", "debug": "^4.4.1", "deterministic-object-hash": "^2.0.2", "devalue": "^5.3.2", "diff": "^5.2.0", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.0", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.3.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.0", "kleur": "^4.1.5", "magic-string": "^0.30.18", "magicast": "^0.3.5", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.0", "package-manager-detector": "^1.3.0", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.2", "shiki": "^3.12.0", "smol-toml": "^1.4.2", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.5.2", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.0", "vfile": "^6.0.3", "vite": "^6.3.6", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.24.6", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-SNURCAlfL4Z2ylF3NMmNk/s3RnSDSolXALXtH0gsN8hFZ7oppnF0sXVQLAGAxnzADemfRp3/9G58EALZ36qUdA=="],
-
-    "astro-theme-toggle": ["astro-theme-toggle@0.6.1", "", {}, "sha512-UkU3ycEHnyl6M39rL3xXXwHfJKEKU0eSQS5dKEL+GInr+JS3jwpt/CCrS3jjc3IN/qVM8lv/gYXZpQx/Bu1Rlw=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@lucide/astro": "^0.525.0",
     "@tailwindcss/vite": "^4.1.11",
     "astro": "5.13.8",
-    "astro-theme-toggle": "^0.6.1",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-external-links": "^3.0.0",
     "tailwindcss": "^4.1.11"

--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -11,7 +11,7 @@ const { title, description, published_date, id } = Astro.props as Props;
 <a href={`/blog/${id}`} class="pb-2 group">
   <div class="flex items-baseline gap-1">
     <h2 class="text-lg font-bold group-hover:underline">{title}</h2>
-    <span class="text-black/60 dark:text-white/60">{published_date}</span>
+    <span class="text-current/60">{published_date}</span>
   </div>
   <p class="text-base">{description}</p>
 </a>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -21,9 +21,6 @@ const links = [
           </li>
         ))
       }
-      <li class="flex items-center">
-        <Toggle style="width: 24px; height: 24px;" />
-      </li>
     </ul>
   </div>
 </nav>

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -1,6 +1,5 @@
 ---
 import { ClientRouter } from "astro:transitions";
-import { ThemeScript } from "astro-theme-toggle";
 import NavBar from "../components/NavBar.astro";
 import "../styles/global.css";
 
@@ -13,7 +12,6 @@ const { title } = Astro.props;
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
-		<ThemeScript />
 		<ClientRouter />
 		<title>{title}</title>
 	</head>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -19,7 +19,7 @@ const { Content } = await render(post);
       <section>
         <h1 class="text-3xl font-bold mb-0">{post.data.title}</h1>
         <div
-          class="flex gap-3 dark:text-white/60 text-black/60 text-base"
+          class="flex gap-3 text-base text-current/60"
         >
           <span>
             {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,28 +1,10 @@
 @import "tailwindcss";
-@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
 :root {
   background-color: #fafafa;
   scrollbar-gutter: stable;
   scroll-behavior: smooth;
   font-family: 'Plus Jakarta Sans', sans;
-}
-
-p {
-  @apply text-black/90 dark:text-white/90;
-}
-
-.dark {
-  background-color: #0f1115;
-}
-
-[data-theme="dark"] .astro-code,
-[data-theme="dark"] .astro-code span {
-  background-color: var(--shiki-dark-bg) !important;
-  color: var(--shiki-dark) !important;
-  font-style: var(--shiki-dark-font-style) !important;
-  font-weight: var(--shiki-dark-font-weight) !important;
-  text-decoration: var(--shiki-dark-text-decoration) !important;
 }
 
 .astro-code,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,13 +7,6 @@
   font-family: 'Plus Jakarta Sans', sans;
 }
 
-.astro-code,
-.astro-code span {
-  font-style: var(--shiki-dark-font-style) !important;
-  font-weight: var(--shiki-dark-font-weight) !important;
-  text-decoration: var(--shiki-dark-text-decoration) !important;
-}
-
 @font-face {
   font-display: swap;
   font-family: 'Plus Jakarta Sans';


### PR DESCRIPTION
This pull request removes support for the `astro-theme-toggle` package and simplifies the site's theme management. It also standardizes text color handling for better consistency across light and dark modes, and updates code block styling to rely less on custom dark theme logic.

**Theme toggle removal and simplification:**

* Removed the `astro-theme-toggle` package from `package.json` and all related imports and components, including the `ThemeScript` and the theme toggle button in the navigation bar. (`[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10)`, `[[2]](diffhunk://#diff-39c5d7b12c3525fb3097716b67a61f490a2aafb95d959ca0898e46d9cbbfc761L3)`, `[[3]](diffhunk://#diff-39c5d7b12c3525fb3097716b67a61f490a2aafb95d959ca0898e46d9cbbfc761L16)`, `[[4]](diffhunk://#diff-c2fa723e39cc162a71e7efe3c4d4264643f48e67c55683d89aa0ca3ff2bfbc81L24-L26)`)
* Removed custom dark theme CSS selectors and styles, including the `.dark` class and `[data-theme="dark"]` code block overrides, from `global.css`. (`[[1]](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL2)`, `[[2]](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL11-L27)`)

**Text color standardization:**

* Updated text color classes for blog cards and blog post headers to use `text-current/60`, ensuring consistent appearance in both light and dark modes. (`[src/components/BlogCard.astroL14-R14](diffhunk://#diff-75e6790b07a61cac3037203a313f5e810e75266a3b8d1de20eb8d22841961d91L14-R14)`, `[src/pages/blog/[...slug].astroL22-R22](diffhunk://#diff-58f768268bbbc17f4c98b8e28c3750d290d43220e52698462b5243f6ebdb3b91L22-R22)`)

**Code block theme adjustment:**

* Modified the Astro Shiki configuration to remove the explicit dark theme setting, relying on the default or light theme only. (`[astro.config.mjsL33](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL33)`)