### PR TITLE
Add meta refresh to redirect to English version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luisfch-website",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "dependencies": {
     "@astrojs/mdx": "4.3.5",
     "@astrojs/node": "9.4.3",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0;url=/en/" />


### PR DESCRIPTION
This pull request makes a small change to the `src/pages/index.astro` file to automatically redirect users from the root URL to the `/en/` path.