### PR TITLE
Change meta redirect to Astro redirect

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,1 +1,3 @@
-<meta http-equiv="refresh" content="0;url=/en/" />
+---
+return Astro.redirect('/en/');
+---


### PR DESCRIPTION
This pull request updates the redirect logic on the `src/pages/index.astro` page to use Astro's built-in redirect functionality instead of a meta refresh tag.

Redirect implementation:

* Replaced the `<meta http-equiv="refresh" content="0;url=/en/" />` tag with `Astro.redirect('/en/')` for a more robust and maintainable redirect approach in `src/pages/index.astro`.