### PR TITLE
Set prerender to false for index page redirection

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,4 @@
 ---
+export const prerender = false
 return Astro.redirect('/en/');
 ---


### PR DESCRIPTION
This pull request introduces a small change to the `src/pages/index.astro` file. The main update is disabling prerendering for the page.

* Disabled prerendering by setting `prerender` to `false` in `src/pages/index.astro`.