### PR TITLE
Add `es` locale fallback to `en`

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,9 @@ export default defineConfig({
   i18n: {
     locales: ['en', 'es'],
     defaultLocale: 'en',
+    fallback: {
+      es: 'en'
+    },
     routing: {
       prefixDefaultLocale: true
     }


### PR DESCRIPTION
This pull request introduces a minor configuration update to the internationalization (i18n) settings. The change ensures that if a translation is missing for Spanish (`es`), the application will fall back to English (`en`).

* Added a `fallback` configuration to the `i18n` settings in `astro.config.mjs`, specifying that Spanish should fall back to English if a translation is unavailable.