### PR TITLE
Add custom 404 page with support for english and spanish

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,9 +16,6 @@ export default defineConfig({
   i18n: {
     locales: ['en', 'es'],
     defaultLocale: 'en',
-    fallback: {
-      es: 'en'
-    },
     routing: {
       prefixDefaultLocale: true
     }

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -8,31 +8,45 @@ export const defaultLanguage = "en";
 export const ui = {
   // file|component.element.identifier...
   en: {
+    // navbar
     'nav.a.home.label': 'Home',
     'nav.a.home.aria': 'Home page',
     'nav.a.blog.label': 'Blog',
     'nav.a.blog.aria': 'Blog page',
     'nav.a.projects.label': 'Projects',
     'nav.a.projects.aria': 'Projects page',
+    // index.astro
     'index.head.title': 'Home | Luis Fonseca',
     'index.h1.greeting': 'Hello there! 👋🏼',
     'index.p.description': "I'm Luis Fonseca, a computer science student at the ",
     'index.p.university': 'University of Costa Rica.',
+    // blog.astro
     'blog.head.title': 'Blog | Luis Fonseca',
     'blog.h1.recent': 'Recent blog posts',
+    // 404.astro
+    '404.head.title': '404 Page Not Found | Luis Fonseca',
+    '404.h1.title': '404 Page Not Found',
+    '404.p.description': "If you are seeing this, you probably tried to access a page that doesn't exist.",
   },
   es: {
+    // navbar
     'nav.a.home.label': 'Inicio',
     'nav.a.home.aria': 'Página de inicio',
     'nav.a.blog.label': 'Blog',
     'nav.a.blog.aria': 'Página del blog',
     'nav.a.projects.label': 'Proyectos',
     'nav.a.projects.aria': 'Página de proyectos',
+    // index.astro
     'index.head.title': 'Inicio | Luis Fonseca',
     'index.h1.greeting': '¡Hola! 👋🏼',
     'index.p.description': 'Soy Luis Fonseca, estudiante de ciencias de la computación en la ',
     'index.p.university': 'Universidad de Costa Rica.',
+    // blog.astro
     'blog.head.title': 'Blog | Luis Fonseca',
     'blog.h1.recent': 'Blogs recientes',
+    // 404.astro
+    '404.head.title': '404 Página No Encontrada | Luis Fonseca',
+    '404.h1.title': '404 Página No Encontrada',
+    '404.p.description': 'Si estás viendo esto, probablemente intentaste acceder a una página que no existe.',
   },
 } as const;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,7 @@
+---
+import { getLangFromUrl } from "../i18n/utils";
+const langUrl = getLangFromUrl(Astro.url);
+export const prerender = false;
+
+return Astro.redirect(`/${langUrl}/404`);
+---

--- a/src/pages/[lang]/404.astro
+++ b/src/pages/[lang]/404.astro
@@ -1,0 +1,22 @@
+---
+import {
+  getLangFromUrl,
+  useTranslations,
+  getLanguageStaticPaths,
+} from "../../i18n/utils";
+import HomeLayout from "../../layouts/HomeLayout.astro";
+
+const urlLang = getLangFromUrl(Astro.url);
+const t = useTranslations(urlLang);
+
+export async function getStaticPaths() {
+  return getLanguageStaticPaths();
+}
+---
+
+<HomeLayout title={t("404.head.title")}>
+  <main class="px-4 py-12 my-8">
+    <h1 class="text-3xl font-bold mb-8">{t("404.h1.title")}</h1>
+    <p class="text-lg">{t("404.p.description")}</p>
+  </main>
+</HomeLayout>

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -18,7 +18,7 @@ const post = Astro.props;
 const { Content } = await render(post);
 ---
 
-<HomeLayout title={`${post.data.title}`}>
+<HomeLayout title={`${post.data.title} | Luis Fonseca`}>
   <main class="px-4 py-12 my-8">
     <article>
       <section>


### PR DESCRIPTION
This pull request improves internationalization (i18n) support and error page handling across the site. The main changes include enhancing translation coverage for the 404 page, restructuring how 404 errors are routed for language-specific handling, and refining page titles for better clarity and SEO.

**Internationalization improvements:**

* Added translation keys for 404 page titles and descriptions in both English and Spanish to the `ui` object in `src/i18n/ui.ts`, ensuring the 404 page is fully localized.

**404 Page and Routing enhancements:**

* Created a new language-specific 404 page at `src/pages/[lang]/404.astro`, which uses translations and a consistent layout. ([src/pages/[lang]/404.astroR1-R22](diffhunk://#diff-01e4ceb34bde8af558277f0a49228594aa4077c115703582a50035cdf3122907R1-R22))
* Updated the generic `src/pages/404.astro` to redirect users to the appropriate language-specific 404 page based on the URL.

**Configuration changes:**

* Removed the fallback language configuration for Spanish in `astro.config.mjs`, so the site will no longer automatically fall back to English for missing Spanish translations.

**Content and SEO improvements:**

* Updated the blog post layout title in `src/pages/[lang]/blog/[...slug].astro` to append the site owner's name, improving clarity and SEO. ([src/pages/[lang]/blog/[...slug].astroL21-R21](diffhunk://#diff-0a6fdd20f554db3617a8b9b94763f9d9d19c7316529aae7f0db116a3afc53264L21-R21))