### PR TITLE
Add projects page

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -15,6 +15,11 @@ const links = [
     label: t("nav.a.blog.label"),
     aria: t("nav.a.blog.aria"),
   },
+  {
+    href: `/${urlLang}/projects`,
+    label: t("nav.a.projects.label"),
+    aria: t("nav.a.projects.aria"),
+  },
 ];
 ---
 

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -11,7 +11,7 @@ const urlLang = getLangFromUrl(Astro.url);
 const slug = id.split("/").slice(1).join("/");
 ---
 
-<a href={`/${urlLang}/blog/${slug}`} class="pb-2 group">
+<a href={`/${urlLang}/projects/${slug}`} class="pb-2 group">
   <div class="flex items-baseline gap-1">
     <h2 class="text-lg font-bold underline decoration-site-primary">{title}</h2>
     {tags.map((tag) => <span class="text-current/60">{tag}</span>)}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,0 +1,20 @@
+---
+import { getLangFromUrl } from "../i18n/utils";
+interface Props {
+  title: string;
+  description: string;
+  tags: string[];
+  id: string;
+}
+const { title, description, tags, id } = Astro.props as Props;
+const urlLang = getLangFromUrl(Astro.url);
+const slug = id.split("/").slice(1).join("/");
+---
+
+<a href={`/${urlLang}/blog/${slug}`} class="pb-2 group">
+  <div class="flex items-baseline gap-1">
+    <h2 class="text-lg font-bold underline decoration-site-primary">{title}</h2>
+    {tags.map((tag) => <span class="text-current/60">{tag}</span>)}
+  </div>
+  <p class="text-base">{description}</p>
+</a>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,4 +15,14 @@ const blog = defineCollection({
   })
 });
 
-export const collections = { blog };
+const projects = defineCollection({
+  loader: glob({ pattern: "**/*.{mdx,md}", base: "./src/data/projects" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    repo_link: z.string().url().optional(),
+    tags: z.array(z.string()).optional(),
+  })
+});
+
+export const collections = { blog, projects };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -20,7 +20,8 @@ const projects = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string(),
-    repo_link: z.string().url().optional(),
+    published_date: z.coerce.date(),
+    repo_url: z.string().url().optional(),
     tags: z.array(z.string()).optional(),
   })
 });

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,8 +21,8 @@ const projects = defineCollection({
     title: z.string(),
     description: z.string(),
     published_date: z.coerce.date(),
-    repo_url: z.string().url().optional(),
-    tags: z.array(z.string()).optional(),
+    repo_url: z.string().url(),
+    tags: z.array(z.string()),
   })
 });
 

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -27,6 +27,9 @@ export const ui = {
     '404.head.title': '404 Page Not Found | Luis Fonseca',
     '404.h1.title': '404 Page Not Found',
     '404.p.description': "If you are seeing this, you probably tried to access a page that doesn't exist.",
+    // projects.astro
+    'projects.head.title': 'Projects | Luis Fonseca',
+    'projects.h1.recent': 'Recent projects',
   },
   es: {
     // navbar
@@ -48,5 +51,8 @@ export const ui = {
     '404.head.title': '404 Página No Encontrada | Luis Fonseca',
     '404.h1.title': '404 Página No Encontrada',
     '404.p.description': 'Si estás viendo esto, probablemente intentaste acceder a una página que no existe.',
+    // projects.astro
+    'projects.head.title': 'Proyectos | Luis Fonseca',
+    'projects.h1.recent': 'Proyectos recientes',
   },
 } as const;

--- a/src/pages/[lang]/projects.astro
+++ b/src/pages/[lang]/projects.astro
@@ -6,7 +6,7 @@ import {
   getLanguageStaticPaths,
 } from "../../i18n/utils";
 import HomeLayout from "../../layouts/HomeLayout.astro";
-import BlogCard from "../../components/BlogCard.astro";
+import ProjectCard from "../../components/ProjectCard.astro";
 
 const urlLang = getLangFromUrl(Astro.url);
 const t = useTranslations(urlLang);
@@ -16,7 +16,9 @@ export async function getStaticPaths() {
 }
 
 const allProjects = await getCollection("projects");
-const projects = allProjects.filter((project) => project.id.startsWith(`${urlLang}`));
+const projects = allProjects.filter((project) =>
+  project.id.startsWith(`${urlLang}`),
+);
 
 // For now I'll show all projects in the same page
 const sortedProjects = projects.sort(
@@ -32,11 +34,14 @@ const sortedProjects = projects.sort(
     <div class="grid gap-2">
       {
         sortedProjects.map((project) => (
-        // TODO: Add project card component
-        <p>{project.data.title}</p>
+          <ProjectCard
+            title={project.data.title}
+            description={project.data.description}
+            tags={project.data.tags}
+            id={project.id}
+          />
         ))
       }
     </div>
   </main>
 </HomeLayout>
-

--- a/src/pages/[lang]/projects.astro
+++ b/src/pages/[lang]/projects.astro
@@ -1,0 +1,42 @@
+---
+import { getCollection } from "astro:content";
+import {
+  getLangFromUrl,
+  useTranslations,
+  getLanguageStaticPaths,
+} from "../../i18n/utils";
+import HomeLayout from "../../layouts/HomeLayout.astro";
+import BlogCard from "../../components/BlogCard.astro";
+
+const urlLang = getLangFromUrl(Astro.url);
+const t = useTranslations(urlLang);
+
+export async function getStaticPaths() {
+  return getLanguageStaticPaths();
+}
+
+const allProjects = await getCollection("projects");
+const projects = allProjects.filter((project) => project.id.startsWith(`${urlLang}`));
+
+// For now I'll show all projects in the same page
+const sortedProjects = projects.sort(
+  (a, b) =>
+    new Date(b.data.published_date).getTime() -
+    new Date(a.data.published_date).getTime(),
+);
+---
+
+<HomeLayout title={t("projects.head.title")}>
+  <main class="px-4 py-12 my-8">
+    <h1 class="text-3xl font-bold mb-8">{t("projects.h1.recent")}</h1>
+    <div class="grid gap-2">
+      {
+        sortedProjects.map((project) => (
+        // TODO: Add project card component
+        <p>{project.data.title}</p>
+        ))
+      }
+    </div>
+  </main>
+</HomeLayout>
+

--- a/src/pages/[lang]/projects/[...slug].astro
+++ b/src/pages/[lang]/projects/[...slug].astro
@@ -1,0 +1,38 @@
+---
+import { getCollection, render } from "astro:content";
+import HomeLayout from "../../../layouts/HomeLayout.astro";
+
+export async function getStaticPaths() {
+  const projects = await getCollection("projects");
+
+  const paths = projects.map((project) => {
+    const [lang, ...slug] = project.id.split("/");
+    return {
+      params: { lang, slug: slug.join("/") || undefined },
+      props: project,
+    };
+  });
+
+  return paths;
+}
+
+const { lang, slug } = Astro.params;
+const project = Astro.props;
+const { Content } = await render(project);
+---
+
+<HomeLayout title={`${project.data.title} | Luis Fonseca`}>
+  <main class="px-4 py-12 my-8">
+    <article>
+      <section>
+        <h1 class="text-3xl font-bold">{project.data.title}</h1>
+        <div class="flex gap-1.5 text-base text-current/60">
+          {project.data.tags.map((tag) => <span>{tag}</span>)}
+        </div>
+      </section>
+      <section class="blog-content">
+        <Content />
+      </section>
+    </article>
+  </main>
+</HomeLayout>


### PR DESCRIPTION
This pull request introduces a new multilingual "Projects" section to the site, allowing users to browse and view details about recent projects in both English and Spanish. The main changes include the creation of new content collections, pages, components, and translations to support this feature.

**Projects Section Implementation**

* Added a new `projects` content collection in `src/content.config.ts` to store project metadata and content.
* Created a new page at `src/pages/[lang]/projects.astro` to display a list of recent projects, sorted by publication date and filtered by language. ([src/pages/[lang]/projects.astroR1-R47](diffhunk://#diff-eb2842e4544a3c03ded0083228d9f7c368f482872072016733b51114b437e4efR1-R47))
* Implemented a dynamic project details page in `src/pages/[lang]/projects/[...slug].astro`, rendering individual project content based on URL parameters. ([src/pages/[lang]/projects/[...slug].astroR1-R38](diffhunk://#diff-70ba4b8f92c71428512b8e160ad83e9df2f98d0ac3cc5bc1e85752162a6c43d4R1-R38))

**Navigation and UI Enhancements**

* Updated the navigation bar in `src/components/NavBar.astro` to include a link to the new Projects section, with language-aware routing.
* Added the `ProjectCard` component in `src/components/ProjectCard.astro` for consistent display of project summaries and tags.

**Localization Support**

* Added English and Spanish translations for project page titles and headings in `src/i18n/ui.ts`. [[1]](diffhunk://#diff-ef401a67d5ffcbe9264ea0f58e2ee2c83507c3b258aa21768e25f232110c6cedR30-R32) [[2]](diffhunk://#diff-ef401a67d5ffcbe9264ea0f58e2ee2c83507c3b258aa21768e25f232110c6cedR54-R56)