### PR TITLE
Add projects section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luisfch-website",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "dependencies": {
     "@astrojs/mdx": "4.3.5",
     "@astrojs/node": "9.4.3",

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -15,6 +15,11 @@ const links = [
     label: t("nav.a.blog.label"),
     aria: t("nav.a.blog.aria"),
   },
+  {
+    href: `/${urlLang}/projects`,
+    label: t("nav.a.projects.label"),
+    aria: t("nav.a.projects.aria"),
+  },
 ];
 ---
 

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -11,7 +11,7 @@ const urlLang = getLangFromUrl(Astro.url);
 const slug = id.split("/").slice(1).join("/");
 ---
 
-<a href={`/${urlLang}/blog/${slug}`} class="pb-2 group">
+<a href={`/${urlLang}/projects/${slug}`} class="pb-2 group">
   <div class="flex items-baseline gap-1">
     <h2 class="text-lg font-bold underline decoration-site-primary">{title}</h2>
     {tags.map((tag) => <span class="text-current/60">{tag}</span>)}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,0 +1,20 @@
+---
+import { getLangFromUrl } from "../i18n/utils";
+interface Props {
+  title: string;
+  description: string;
+  tags: string[];
+  id: string;
+}
+const { title, description, tags, id } = Astro.props as Props;
+const urlLang = getLangFromUrl(Astro.url);
+const slug = id.split("/").slice(1).join("/");
+---
+
+<a href={`/${urlLang}/blog/${slug}`} class="pb-2 group">
+  <div class="flex items-baseline gap-1">
+    <h2 class="text-lg font-bold underline decoration-site-primary">{title}</h2>
+    {tags.map((tag) => <span class="text-current/60">{tag}</span>)}
+  </div>
+  <p class="text-base">{description}</p>
+</a>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,4 +15,14 @@ const blog = defineCollection({
   })
 });
 
-export const collections = { blog };
+const projects = defineCollection({
+  loader: glob({ pattern: "**/*.{mdx,md}", base: "./src/data/projects" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    repo_link: z.string().url().optional(),
+    tags: z.array(z.string()).optional(),
+  })
+});
+
+export const collections = { blog, projects };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -20,7 +20,8 @@ const projects = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string(),
-    repo_link: z.string().url().optional(),
+    published_date: z.coerce.date(),
+    repo_url: z.string().url().optional(),
     tags: z.array(z.string()).optional(),
   })
 });

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,8 +21,8 @@ const projects = defineCollection({
     title: z.string(),
     description: z.string(),
     published_date: z.coerce.date(),
-    repo_url: z.string().url().optional(),
-    tags: z.array(z.string()).optional(),
+    repo_url: z.string().url(),
+    tags: z.array(z.string()),
   })
 });
 

--- a/src/data/projects/en/medline-xml-parser.md
+++ b/src/data/projects/en/medline-xml-parser.md
@@ -1,0 +1,130 @@
+---
+title: "Medline XML Parser"
+description: " Implementation of a lexical and syntactic parser for Medline XML files."
+published_date: 09-25-2025
+repo_url: "https://github.com/luis-fch/tareas-programadas-los-heuristicos"
+tags: ["Python", "Flask", "Jinja"]
+---
+
+This project was part of the assignments for the **CI0124 Computability and Complexity** course at the University of Costa Rica and was developed by a group of three people.
+
+## Description
+
+The assignment consisted of developing a lexical and syntactic parser for MedlinePlus XML files. The main goal was to extract relevant information from these files and present it in a structured way.
+
+## Technologies
+
+For the lexical and syntactic parser we used Ply (Python Lex-Yacc), a tool that facilitates creating parsers in Python. Ply allowed us to define lexical and grammar rules to efficiently process MedlinePlus XML files.
+
+For the web interface, we used Flask, a web framework for Python, along with Jinja templates to render HTML pages dynamically.
+
+## Implementation
+
+The project was organized into several stages according to the material covered in class:
+
+### First stage
+
+In the first stage we prepared the specification: list of planned features, the data structure model, and a mockup of the interface.
+
+### Second stage
+
+In the second stage we implemented only the lexical analyzer. We started using Ply and defined the tokens and lexical rules needed to identify elements of the XML file.
+
+For the tokens:
+
+```python
+tokens = (
+  # xml
+  'XML_OP',
+  'XML_CL',
+
+  # xml attributes
+  'VERSION',
+  'ENCODING',
+
+  # doctype
+  'DOCTYPE',
+
+  # health-topics
+  'HEALTH_TOPICS_OP',
+  'HEALTH_TOPICS_CL',
+
+  # health-topics attributes
+  'TOTAL',
+  'DATE_GENERATED',
+
+  # health-topic
+  'HEALTH_TOPIC_OP',
+  'HEALTH_TOPIC_CL',
+
+  # health-topic attributes
+  'META_DESC',
+  'TITLE',
+  'URL',
+  'ID',
+  'LANGUAGE',
+  'DATE_CREATED',
+
+  # and so on...
+)
+```
+
+For the lexical rules we defined regular expressions for each token:
+
+```python
+# health-topic, group, descriptor, other-language, primary-institute,
+#   site attributes, related-topic and qualifier
+t_META_DESC = r'meta-desc="[^"]*"'
+t_TITLE = r'title="[^"]*"'
+t_URL = r'url="https?:\/\/(?:www\.)?[-\w]+(?:\.[ \w]+)+(:\d+)?(\/[-\w.\/?%&=+;:#,\[\]\(\)\' ]*)?"'
+t_LANGUAGE_MAPPED_URL = r'language-mapped-url="https?:\/\/(?:www\.)?[-\w]+(?:\.[-\w]+)+(:\d+)?(\/[-\w.\/?%&=#]*)?"'
+t_ID = r'id="[\d\w]*"'
+t_LANGUAGE = r'language="(English|Spanish)"'
+t_DATE_CREATED = r'date-created="(0?[1-9]|1[0-2])\/(0?[1-9]|[12][0-9]|3[01])\/\d{4}"'
+t_VERNACULAR_NAME = r'vernacular-name="([\s\S]*?)"'
+
+t_ALSO_CALLED_OP = r'<also-called>'
+t_ALSO_CALLED_CL = r'</also-called>'
+
+# and so on...
+```
+
+### Third stage
+
+In this submission we implemented the syntactic analyzer. We defined grammar rules that structured the information extracted by the lexical analyzer. At that time there was no graphical interface, so the output was printed to the console.
+
+Some examples of the grammar rules defined:
+
+```python
+def p_document(t):
+    'document : header body'
+
+def p_header(t):
+    'header : xml DOCTYPE'
+    print(f"""Header:
+    {t[1]}
+    {t[2]}
+    """)
+
+def p_body(t):
+    'body : HEALTH_TOPICS_OP TOTAL DATE_GENERATED CLOSE health_topic_list HEALTH_TOPICS_CL'
+    print("Body: ", t[2], t[3])
+
+def p_health_topic_list(t):
+    '''health_topic_list : health_topic health_topic_list
+                         | empty'''
+
+# and so on...
+```
+
+### Fourth stage
+
+In this delivery we added a data structure to store the extracted information. We decided to use classes and dictionaries to keep the data in a structured manner.
+
+### Fifth stage
+
+Finally, in the last delivery we incorporated a simple web interface using Flask and Jinja templates. In this interface the user can upload an XML file and view the extracted information structured in the browser.
+
+#### Screenshots
+
+<!-- TODO: Add screenshots later in the repo -->

--- a/src/data/projects/en/medline-xml-parser.md
+++ b/src/data/projects/en/medline-xml-parser.md
@@ -127,4 +127,14 @@ Finally, in the last delivery we incorporated a simple web interface using Flask
 
 #### Screenshots
 
-<!-- TODO: Add screenshots later in the repo -->
+![image](https://github.com/user-attachments/assets/80a776bf-69d3-4b63-b354-6626f740fd4e)
+
+![image](https://github.com/user-attachments/assets/a2844d3f-7d4e-4b53-86cb-cb19d298c460)
+
+![image](https://github.com/user-attachments/assets/72be390c-16fe-429c-90a8-85b44f6c1201)
+
+![image](https://github.com/user-attachments/assets/bb6bcd01-998b-4f08-80a4-1bab39efba11)
+
+![image](https://github.com/user-attachments/assets/6efb9757-6f2c-476c-a9c1-9791fd8c5fae)
+
+![image](https://github.com/user-attachments/assets/d2a5b876-2e10-48a3-844a-0cd1661f7e4a)

--- a/src/data/projects/es/medline-xml-parser.md
+++ b/src/data/projects/es/medline-xml-parser.md
@@ -16,6 +16,8 @@ La tarea consistió en desarrollar un analizador léxico y sintáctico para arch
 
 Para la parte del analizador léxico y sintáctico utilizamos Ply (Python Lex-Yacc), una herramienta que facilita la creación de analizadores en Python. Ply nos permitió definir reglas léxicas y gramaticales para procesar los archivos XML de MedlinePlus de forma eficiente.
 
+Para la interfaz web utilizamos Flask, un framework web para Python, junto con plantillas Jinja para renderizar dinámicamente las páginas HTML.
+
 ## Implementación
 
 El proyecto se estructuró en varias etapas según la materia vista en clase:
@@ -117,7 +119,7 @@ def p_health_topic_list(t):
 
 ### Cuarta etapa
 
-En esta entrega añadimos una estructura de datos para almacenar la información extraída. Decidimos usar un diccionario de Python para mantener los datos de forma jerárquica.
+En esta entrega añadimos una estructura de datos para almacenar la información extraída. Decidimos usar clases y diccionarios para mantener los datos de manera estructurada.
 
 ### Quinta etapa
 

--- a/src/data/projects/es/medline-xml-parser.md
+++ b/src/data/projects/es/medline-xml-parser.md
@@ -127,14 +127,14 @@ Finalmente, en la última entrega incorporamos una interfaz web sencilla usando 
 
 #### Capturas
 
-<img width="2450" height="1531" alt="image" src="https://github.com/user-attachments/assets/80a776bf-69d3-4b63-b354-6626f740fd4e" />
+![image](https://github.com/user-attachments/assets/80a776bf-69d3-4b63-b354-6626f740fd4e)
 
-<img width="2450" height="1542" alt="image" src="https://github.com/user-attachments/assets/a2844d3f-7d4e-4b53-86cb-cb19d298c460" />
+![image](https://github.com/user-attachments/assets/a2844d3f-7d4e-4b53-86cb-cb19d298c460)
 
-<img width="2528" height="1594" alt="image" src="https://github.com/user-attachments/assets/72be390c-16fe-429c-90a8-85b44f6c1201" />
+![image](https://github.com/user-attachments/assets/72be390c-16fe-429c-90a8-85b44f6c1201)
 
-<img width="2520" height="1594" alt="image" src="https://github.com/user-attachments/assets/bb6bcd01-998b-4f08-80a4-1bab39efba11" />
+![image](https://github.com/user-attachments/assets/bb6bcd01-998b-4f08-80a4-1bab39efba11)
 
-<img width="2457" height="1543" alt="image" src="https://github.com/user-attachments/assets/6efb9757-6f2c-476c-a9c1-9791fd8c5fae" />
+![image](https://github.com/user-attachments/assets/6efb9757-6f2c-476c-a9c1-9791fd8c5fae)
 
-<img width="2452" height="1539" alt="image" src="https://github.com/user-attachments/assets/d2a5b876-2e10-48a3-844a-0cd1661f7e4a" />
+![image](https://github.com/user-attachments/assets/d2a5b876-2e10-48a3-844a-0cd1661f7e4a)

--- a/src/data/projects/es/medline-xml-parser.md
+++ b/src/data/projects/es/medline-xml-parser.md
@@ -1,0 +1,128 @@
+---
+title: "Medline XML Parser"
+description: "Implementación de un analizador léxico y sintáctico para archivos XML de Medline."
+published_date: 09-25-2025
+repo_url: "https://github.com/luis-fch/tareas-programadas-los-heuristicos"
+tags: ["Python", "Flask", "Jinja"]
+---
+
+Este proyecto formó parte de las tareas del curso **CI0124 Computabilidad y Complejidad** de la Universidad de Costa Rica y lo desarrollamos en un grupo de tres personas.
+
+## Descripción
+
+La tarea consistió en desarrollar un analizador léxico y sintáctico para archivos XML de MedlinePlus. El objetivo principal fue extraer información relevante de estos archivos y presentarla de manera estructurada.
+
+## Tecnologías
+
+Para la parte del analizador léxico y sintáctico utilizamos Ply (Python Lex-Yacc), una herramienta que facilita la creación de analizadores en Python. Ply nos permitió definir reglas léxicas y gramaticales para procesar los archivos XML de MedlinePlus de forma eficiente.
+
+## Implementación
+
+El proyecto se estructuró en varias etapas según la materia vista en clase:
+
+### Primera etapa
+
+En la primera etapa elaboramos la especificación: lista de funcionalidades previstas, modelo de la estructura de datos y un mockup de la interfaz.
+
+### Segunda etapa
+
+En la segunda etapa implementamos únicamente el analizador léxico. Empezamos a usar Ply y definimos los tokens y las reglas léxicas necesarias para identificar los elementos del archivo XML.
+
+En el caso de los tokens:
+
+```python
+tokens = (
+  # xml
+  'XML_OP',
+  'XML_CL',
+
+  # xml attributes
+  'VERSION',
+  'ENCODING',
+
+  # doctype
+  'DOCTYPE',
+
+  # health-topics
+  'HEALTH_TOPICS_OP',
+  'HEALTH_TOPICS_CL',
+
+  # health-topics attributes
+  'TOTAL',
+  'DATE_GENERATED',
+
+  # health-topic
+  'HEALTH_TOPIC_OP',
+  'HEALTH_TOPIC_CL',
+
+  # health-topic attributes
+  'META_DESC',
+  'TITLE',
+  'URL',
+  'ID',
+  'LANGUAGE',
+  'DATE_CREATED',
+
+  # y así sucesivamente...
+)
+```
+
+Para las reglas léxicas definimos expresiones regulares para cada token:
+
+```python
+# health-topic, group, descriptor, other-language, primary-institute,
+#   site attributes, related-topic and qualifier
+t_META_DESC = r'meta-desc="[^"]*"'
+t_TITLE = r'title="[^"]*"'
+t_URL = r'url="https?:\/\/(?:www\.)?[-\w]+(?:\.[ \w]+)+(:\d+)?(\/[-\w.\/?%&=+;:#,\[\]\(\)\' ]*)?"'
+t_LANGUAGE_MAPPED_URL = r'language-mapped-url="https?:\/\/(?:www\.)?[-\w]+(?:\.[-\w]+)+(:\d+)?(\/[-\w.\/?%&=#]*)?"'
+t_ID = r'id="[\d\w]*"'
+t_LANGUAGE = r'language="(English|Spanish)"'
+t_DATE_CREATED = r'date-created="(0?[1-9]|1[0-2])\/(0?[1-9]|[12][0-9]|3[01])\/\d{4}"'
+t_VERNACULAR_NAME = r'vernacular-name="([\s\S]*?)"'
+
+t_ALSO_CALLED_OP = r'<also-called>'
+t_ALSO_CALLED_CL = r'</also-called>'
+
+# y así sucesivamente...
+```
+
+### Tercera etapa
+
+En esta entrega implementamos el analizador sintáctico. Definimos las reglas gramaticales que permitieron estructurar la información extraída por el analizador léxico. En ese momento no existía interfaz gráfica, solo se imprimía en consola.
+
+Algunos ejemplos de las reglas gramaticales definidas:
+
+```python
+def p_document(t):
+    'document : header body'
+
+def p_header(t):
+    'header : xml DOCTYPE'
+    print(f"""Header:
+    {t[1]}
+    {t[2]}
+    """)
+
+def p_body(t):
+    'body : HEALTH_TOPICS_OP TOTAL DATE_GENERATED CLOSE health_topic_list HEALTH_TOPICS_CL'
+    print("Body: ", t[2], t[3])
+
+def p_health_topic_list(t):
+    '''health_topic_list : health_topic health_topic_list
+                         | empty'''
+
+# y así sucesivamente...
+```
+
+### Cuarta etapa
+
+En esta entrega añadimos una estructura de datos para almacenar la información extraída. Decidimos usar un diccionario de Python para mantener los datos de forma jerárquica.
+
+### Quinta etapa
+
+Finalmente, en la última entrega incorporamos una interfaz web sencilla usando Flask y plantillas Jinja. En esta interfaz permitimos al usuario subir un archivo XML y visualizar la información extraída de forma estructurada en el navegador.
+
+#### Capturas
+
+<!-- TODO: Agregar capturas luego en el repo -->

--- a/src/data/projects/es/medline-xml-parser.md
+++ b/src/data/projects/es/medline-xml-parser.md
@@ -127,4 +127,14 @@ Finalmente, en la última entrega incorporamos una interfaz web sencilla usando 
 
 #### Capturas
 
-<!-- TODO: Agregar capturas luego en el repo -->
+<img width="2450" height="1531" alt="image" src="https://github.com/user-attachments/assets/80a776bf-69d3-4b63-b354-6626f740fd4e" />
+
+<img width="2450" height="1542" alt="image" src="https://github.com/user-attachments/assets/a2844d3f-7d4e-4b53-86cb-cb19d298c460" />
+
+<img width="2528" height="1594" alt="image" src="https://github.com/user-attachments/assets/72be390c-16fe-429c-90a8-85b44f6c1201" />
+
+<img width="2520" height="1594" alt="image" src="https://github.com/user-attachments/assets/bb6bcd01-998b-4f08-80a4-1bab39efba11" />
+
+<img width="2457" height="1543" alt="image" src="https://github.com/user-attachments/assets/6efb9757-6f2c-476c-a9c1-9791fd8c5fae" />
+
+<img width="2452" height="1539" alt="image" src="https://github.com/user-attachments/assets/d2a5b876-2e10-48a3-844a-0cd1661f7e4a" />

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -27,6 +27,9 @@ export const ui = {
     '404.head.title': '404 Page Not Found | Luis Fonseca',
     '404.h1.title': '404 Page Not Found',
     '404.p.description': "If you are seeing this, you probably tried to access a page that doesn't exist.",
+    // projects.astro
+    'projects.head.title': 'Projects | Luis Fonseca',
+    'projects.h1.recent': 'Recent projects',
   },
   es: {
     // navbar
@@ -48,5 +51,8 @@ export const ui = {
     '404.head.title': '404 Página No Encontrada | Luis Fonseca',
     '404.h1.title': '404 Página No Encontrada',
     '404.p.description': 'Si estás viendo esto, probablemente intentaste acceder a una página que no existe.',
+    // projects.astro
+    'projects.head.title': 'Proyectos | Luis Fonseca',
+    'projects.h1.recent': 'Proyectos recientes',
   },
 } as const;

--- a/src/pages/[lang]/projects.astro
+++ b/src/pages/[lang]/projects.astro
@@ -6,7 +6,7 @@ import {
   getLanguageStaticPaths,
 } from "../../i18n/utils";
 import HomeLayout from "../../layouts/HomeLayout.astro";
-import BlogCard from "../../components/BlogCard.astro";
+import ProjectCard from "../../components/ProjectCard.astro";
 
 const urlLang = getLangFromUrl(Astro.url);
 const t = useTranslations(urlLang);
@@ -16,7 +16,9 @@ export async function getStaticPaths() {
 }
 
 const allProjects = await getCollection("projects");
-const projects = allProjects.filter((project) => project.id.startsWith(`${urlLang}`));
+const projects = allProjects.filter((project) =>
+  project.id.startsWith(`${urlLang}`),
+);
 
 // For now I'll show all projects in the same page
 const sortedProjects = projects.sort(
@@ -32,11 +34,14 @@ const sortedProjects = projects.sort(
     <div class="grid gap-2">
       {
         sortedProjects.map((project) => (
-        // TODO: Add project card component
-        <p>{project.data.title}</p>
+          <ProjectCard
+            title={project.data.title}
+            description={project.data.description}
+            tags={project.data.tags}
+            id={project.id}
+          />
         ))
       }
     </div>
   </main>
 </HomeLayout>
-

--- a/src/pages/[lang]/projects.astro
+++ b/src/pages/[lang]/projects.astro
@@ -1,0 +1,42 @@
+---
+import { getCollection } from "astro:content";
+import {
+  getLangFromUrl,
+  useTranslations,
+  getLanguageStaticPaths,
+} from "../../i18n/utils";
+import HomeLayout from "../../layouts/HomeLayout.astro";
+import BlogCard from "../../components/BlogCard.astro";
+
+const urlLang = getLangFromUrl(Astro.url);
+const t = useTranslations(urlLang);
+
+export async function getStaticPaths() {
+  return getLanguageStaticPaths();
+}
+
+const allProjects = await getCollection("projects");
+const projects = allProjects.filter((project) => project.id.startsWith(`${urlLang}`));
+
+// For now I'll show all projects in the same page
+const sortedProjects = projects.sort(
+  (a, b) =>
+    new Date(b.data.published_date).getTime() -
+    new Date(a.data.published_date).getTime(),
+);
+---
+
+<HomeLayout title={t("projects.head.title")}>
+  <main class="px-4 py-12 my-8">
+    <h1 class="text-3xl font-bold mb-8">{t("projects.h1.recent")}</h1>
+    <div class="grid gap-2">
+      {
+        sortedProjects.map((project) => (
+        // TODO: Add project card component
+        <p>{project.data.title}</p>
+        ))
+      }
+    </div>
+  </main>
+</HomeLayout>
+

--- a/src/pages/[lang]/projects/[...slug].astro
+++ b/src/pages/[lang]/projects/[...slug].astro
@@ -1,0 +1,38 @@
+---
+import { getCollection, render } from "astro:content";
+import HomeLayout from "../../../layouts/HomeLayout.astro";
+
+export async function getStaticPaths() {
+  const projects = await getCollection("projects");
+
+  const paths = projects.map((project) => {
+    const [lang, ...slug] = project.id.split("/");
+    return {
+      params: { lang, slug: slug.join("/") || undefined },
+      props: project,
+    };
+  });
+
+  return paths;
+}
+
+const { lang, slug } = Astro.params;
+const project = Astro.props;
+const { Content } = await render(project);
+---
+
+<HomeLayout title={`${project.data.title} | Luis Fonseca`}>
+  <main class="px-4 py-12 my-8">
+    <article>
+      <section>
+        <h1 class="text-3xl font-bold">{project.data.title}</h1>
+        <div class="flex gap-1.5 text-base text-current/60">
+          {project.data.tags.map((tag) => <span>{tag}</span>)}
+        </div>
+      </section>
+      <section class="blog-content">
+        <Content />
+      </section>
+    </article>
+  </main>
+</HomeLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -99,7 +99,7 @@
 
 /* Images */
 .blog-content img {
-  @apply max-w-full h-auto my-4 rounded-lg mx-auto;
+  @apply max-w-full h-auto my-4 rounded-lg border-2 border-site-primary mx-auto;
 }
 
 /* Links */


### PR DESCRIPTION
This pull request introduces a new multilingual projects section to the site, allowing users to browse and view detailed information about recent projects in both English and Spanish. It adds content collections, pages, components, and translations to support this feature, and includes a sample project entry. There are also minor style improvements for images.

**Projects Section Implementation**

* Added a new `projects` content collection in `src/content.config.ts` to organize project entries and their metadata, supporting Markdown and MDX formats.
* Created new pages: `src/pages/[lang]/projects.astro` lists recent projects per language, and `src/pages/[lang]/projects/[...slug].astro` displays detailed project information. ([src/pages/[lang]/projects.astroR1-R47](diffhunk://#diff-eb2842e4544a3c03ded0083228d9f7c368f482872072016733b51114b437e4efR1-R47), [src/pages/[lang]/projects/[...slug].astroR1-R38](diffhunk://#diff-70ba4b8f92c71428512b8e160ad83e9df2f98d0ac3cc5bc1e85752162a6c43d4R1-R38))
* Added a reusable `ProjectCard.astro` component for displaying project previews in the projects list.
* Added sample project entries in both English and Spanish (`medline-xml-parser.md`) under `src/data/projects/en/` and `src/data/projects/es/`. [[1]](diffhunk://#diff-2ca5e192e839d628eb367782840fd3969e25ac7f2ff23935d36b65cfbe1039eaR1-R140) [[2]](diffhunk://#diff-615224f1c072cbcaaa54f3df52cd95a17530a0e54101ff7ea931b3c654b6e351R1-R140)

**Navigation and Internationalization**

* Updated navigation links in `NavBar.astro` to include the new projects section, respecting the current language.
* Added translation keys for the projects pages in both English and Spanish in `src/i18n/ui.ts`. [[1]](diffhunk://#diff-ef401a67d5ffcbe9264ea0f58e2ee2c83507c3b258aa21768e25f232110c6cedR30-R32) [[2]](diffhunk://#diff-ef401a67d5ffcbe9264ea0f58e2ee2c83507c3b258aa21768e25f232110c6cedR54-R56)

**Styling**

* Improved image styling in `.blog-content` by adding a border for better visual distinction.